### PR TITLE
Add license to manifest in order to redistribute it.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,4 +1,5 @@
 Makefile
+LICENSE
 README.rst
 CHANGES.rst
 crlibm/AUTHORS


### PR DESCRIPTION
Hi Stefano, I'm creating conda packages for pyinterval and pycrlibm and they require the license file to be packaged.
Thanks!
Regards, Mark