### PR TITLE
Fix ModuleNotFoundError during pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools<75.0.0"]
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
When trying to `pip install crlibm`, a `ModuleNotFoundError` appears, breaking the install.

The module not found is `distutils.command.upload`, which has been [removed](https://github.com/pypa/setuptools/commit/af9e245b57ef78fce03c7e28a0189388d8e4de18#diff-4e6d4ff062c4d0000d019ef11a0890f25449eb1891f8e704745341faab7659a4) in setuptools' recently published version 75.0.0. That module is depended upon by this project's `setup.py`.

When the build dependencies haven't been declared, pip will follow [this fallback behavior](https://github.com/pypa/pip/blob/102d8187a1f5a4cd5de7a549fd8a9af34e89a54f/docs/html/reference/build-system/pyproject-toml.md?plain=1#L131-L147) and fetch the latest version of setuptools, which from above is no longer compatible.

To fix the issue, this PR adds a minimal `pyproject.toml` file to declare a dependency on setuptools prior to the breaking version.


### How to reproduce

```bash
# Must have Python 3.12 installed
python --version
# Python 3.12.1

# Create an empty Python virtual environment
python -m venv .venv

# Activate the virtual environment
source .venv/bin/activate

# Install crlibm, providing a local path to the git repo
pip install ../crlibm  # <-- this fails, see error below

# To test that the library installed correctly
python -c 'import crlibm ; print(crlibm.exp_ru(1))'
# Should print: 2.7182818284590455
```

### Example error message

```
Processing /Users/alvin/Projects/pycrlibm
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [20 lines of output]
      Traceback (most recent call last):
        File "/Users/alvin/Projects/pycrlibm-sandbox/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/Users/alvin/Projects/pycrlibm-sandbox/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Users/alvin/Projects/pycrlibm-sandbox/.venv/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/tb/wv_dy5_j309_plh4f12tg3hr0000gn/T/pip-build-env-ipu4bbgt/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 332, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/tb/wv_dy5_j309_plh4f12tg3hr0000gn/T/pip-build-env-ipu4bbgt/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 302, in _get_build_requires
          self.run_setup()
        File "/private/var/folders/tb/wv_dy5_j309_plh4f12tg3hr0000gn/T/pip-build-env-ipu4bbgt/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 503, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/private/var/folders/tb/wv_dy5_j309_plh4f12tg3hr0000gn/T/pip-build-env-ipu4bbgt/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 318, in run_setup
          exec(code, locals())
        File "<string>", line 15, in <module>
      ModuleNotFoundError: No module named 'distutils.command.upload'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

### Workaround

For projects that depend on crlibm while this fix hasn't been merged, I have found a workaround.

- Add `setuptools<75.0.0` to your project dependencies (to install the version of setuptools prior to the breaking change)
- Use the `--no-build-isolation` flag when you do `pip install` or `uv sync` (to use build dependencies defined in your project rather than in each dependency)

**Note that this is a very precarious workaround** - it assumes all your dependencies can be built with the same build dependencies.
